### PR TITLE
Fixed capitalisation issue in variable - headers were dropped for outgoing

### DIFF
--- a/code/email/CaptureMailer.php
+++ b/code/email/CaptureMailer.php
@@ -53,7 +53,7 @@ class CaptureMailer extends Mailer {
 		}
 		
 		if (self::$outbound_send) {
-			return parent::sendPlain($to, $from, $subject, $plainContent, $attachedFiles, $customheaders);
+			return parent::sendPlain($to, $from, $subject, $plainContent, $attachedFiles, $customHeaders);
 		}
 		
 		return true;


### PR DESCRIPTION
Minor typo in variable name resulted in headers not being passed on for outgoing emails.
