### PR TITLE
Specific route that picks up CapturedEmailController/

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,5 +1,5 @@
 ---
-Name: mysiteroutes
+Name: mailcaptureroutes
 After: framework/routes#coreroutes
 ---
 Director:

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,0 +1,7 @@
+---
+Name: mysiteroutes
+After: framework/routes#coreroutes
+---
+Director:
+    rules:
+        'CapturedEmailController//$ID' : 'CapturedEmailController'


### PR DESCRIPTION
After moving from SS3.1 to later (3.2) found that the URL to view captured emails was resulting in a 404.
